### PR TITLE
Add calculator-based Cucumber examples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,13 @@
         </dependency>
 
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>5.3.0</version>

--- a/src/test/java/org/example/RunCucumberTest.java
+++ b/src/test/java/org/example/RunCucumberTest.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = "src/test/resources/features",
+        plugin = {"pretty"},
+        glue = {"org.example.steps"}
+)
+public class RunCucumberTest {
+}

--- a/src/test/java/org/example/steps/CalculatorSteps.java
+++ b/src/test/java/org/example/steps/CalculatorSteps.java
@@ -1,0 +1,52 @@
+package org.example.steps;
+
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CalculatorSteps {
+    private final List<Integer> numbers = new ArrayList<>();
+    private int result;
+
+    @Given("the calculator is cleared")
+    public void the_calculator_is_cleared() {
+        numbers.clear();
+        result = 0;
+    }
+
+    @Given("I have entered {int} into the calculator")
+    public void i_have_entered_into_the_calculator(int number) {
+        numbers.add(number);
+    }
+
+    @When("I press add")
+    public void i_press_add() {
+        result = numbers.stream().mapToInt(Integer::intValue).sum();
+    }
+
+    @When("I press multiply")
+    public void i_press_multiply() {
+        result = numbers.stream().reduce(1, (left, right) -> left * right);
+    }
+
+    @Given("the following numbers:")
+    public void the_following_numbers(DataTable table) {
+        numbers.clear();
+        numbers.addAll(table.asList(Integer.class));
+    }
+
+    @When("I total them")
+    public void i_total_them() {
+        result = numbers.stream().mapToInt(Integer::intValue).sum();
+    }
+
+    @Then("the result should be {int}")
+    public void the_result_should_be(int expected) {
+        Assert.assertEquals(expected, result);
+    }
+}

--- a/src/test/resources/features/calculator.feature
+++ b/src/test/resources/features/calculator.feature
@@ -1,0 +1,32 @@
+Feature: Basic calculator operations
+  As a curious tester
+  I want to experiment with Cucumber step definitions
+  So that I can learn how to describe executable specifications
+
+  Scenario: Add two numbers
+    Given the calculator is cleared
+    And I have entered 5 into the calculator
+    And I have entered 7 into the calculator
+    When I press add
+    Then the result should be 12
+
+  Scenario Outline: Multiply two numbers
+    Given the calculator is cleared
+    And I have entered <first> into the calculator
+    And I have entered <second> into the calculator
+    When I press multiply
+    Then the result should be <product>
+
+    Examples:
+      | first | second | product |
+      | 2     | 3      | 6       |
+      | 7     | 8      | 56      |
+
+  Scenario: Add a list of numbers
+    Given the following numbers:
+      | 4  |
+      | 8  |
+      | 15 |
+      | 16 |
+    When I total them
+    Then the result should be 43


### PR DESCRIPTION
## Summary
- add a sample calculator feature with scenarios for addition, multiplication, and summing tables
- implement Cucumber step definitions and a JUnit runner to execute the examples
- include the JUnit dependency required to run the scenarios with the Cucumber JUnit runner

## Testing
- mvn test *(fails: Maven cannot download plugins from Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df0161cdec83208647c3e36fac9f97